### PR TITLE
Feature / [3] Add PDF parsing logic

### DIFF
--- a/.github/workflows/code_analysis_action.yml
+++ b/.github/workflows/code_analysis_action.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Install poppler-utils
+        run: sudo apt-get update && sudo apt-get install -y poppler-utils
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -63,3 +63,5 @@ gem 'ffi', '1.16.3'
 
 gem 'rainbow', '~> 3.1'
 gem 'pdf-reader'
+gem 'cv-parser'
+gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,8 +72,19 @@ GEM
       msgpack (~> 1.2)
     builder (3.3.0)
     byebug (11.1.3)
+    cgi (0.5.0)
     concurrent-ruby (1.3.4)
     crass (1.0.6)
+    cv-parser (0.1.2)
+      base64 (~> 0.2)
+      faraday (>= 1.0)
+      faraday-multipart (>= 1.0)
+      fiddle (~> 1.1)
+      json (~> 2.6)
+      mime-types (~> 3.5)
+      rdoc (~> 6.6)
+      rexml (~> 3.2)
+      zlib (~> 3.0)
     date (3.4.1)
     devise (4.9.4)
       bcrypt (~> 3.0)
@@ -98,6 +109,8 @@ GEM
     dry-core (1.0.0)
       concurrent-ruby (~> 1.0)
       zeitwerk (~> 2.6)
+    erb (4.0.4)
+      cgi (>= 0.3.3)
     erubi (1.13.1)
     factory_bot (6.4.5)
       activesupport (>= 5.0.0)
@@ -106,7 +119,15 @@ GEM
       railties (>= 5.0.0)
     faker (3.4.2)
       i18n (>= 1.8.11, < 2)
+    faraday (2.8.1)
+      base64
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-multipart (1.1.1)
+      multipart-post (~> 2.0)
+    faraday-net_http (3.0.2)
     ffi (1.16.3)
+    fiddle (1.1.8)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashery (2.1.2)
@@ -134,10 +155,15 @@ GEM
       net-smtp
     marcel (1.0.4)
     method_source (1.1.0)
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2025.0902)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (5.25.5)
     msgpack (1.8.0)
+    multipart-post (2.4.1)
     net-imap (0.4.22)
       date
       net-protocol
@@ -164,6 +190,9 @@ GEM
       ttfunk
     pg (1.5.9)
     prism (1.4.0)
+    psych (5.2.6)
+      date
+      stringio
     public_suffix (5.1.1)
     puma (5.6.9)
       nio4r (~> 2.0)
@@ -206,10 +235,14 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
+    rdoc (6.14.2)
+      erb
+      psych (>= 4.0.0)
     regexp_parser (2.10.0)
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rexml (3.4.3)
     rspec-core (3.13.5)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
@@ -267,6 +300,7 @@ GEM
       rubocop-ast (>= 1.44.0, < 2.0)
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
+    ruby2_keywords (0.0.5)
     spring (2.1.1)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
@@ -276,6 +310,7 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    stringio (3.1.7)
     thor (1.4.0)
     timeout (0.4.3)
     tsort (0.2.0)
@@ -298,6 +333,7 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     zeitwerk (2.6.18)
+    zlib (3.2.1)
 
 PLATFORMS
   ruby
@@ -306,6 +342,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   concurrent-ruby (< 1.3.5)
+  cv-parser
   devise (~> 4.9)
   devise-jwt
   dotenv-rails
@@ -313,6 +350,7 @@ DEPENDENCIES
   faker
   ffi (= 1.16.3)
   listen (~> 3.3)
+  nokogiri
   pdf-reader
   pg (~> 1.1)
   puma (~> 5.0)

--- a/app/controllers/api/cvs_controller.rb
+++ b/app/controllers/api/cvs_controller.rb
@@ -35,21 +35,15 @@ module Api
 
     def extract_text
       cv = CvUpload.find_by(id: params[:id])
-
       return render json: { error: 'CV not found' }, status: :not_found unless cv&.file&.attached?
 
-      file_path = ActiveStorage::Blob.service.send(:path_for, cv.file.key)
-
-      text = extract_pdf_text(file_path)
-
-      render json: { text: text }, status: :ok
-    end
-
-    private
-
-    def extract_pdf_text(path)
-      reader = PDF::Reader.new(path)
-      reader.pages.map(&:text).join("\n")
+      begin
+        result = PdfParserService.new(cv.file).extract_text
+        render json: result, status: :ok
+      rescue StandardError => e
+        render json: { error: 'Failed to extract text', details: e.message },
+               status: :unprocessable_entity
+      end
     end
   end
 end

--- a/app/services/pdf_parser_service.rb
+++ b/app/services/pdf_parser_service.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'nokogiri'
+require 'securerandom'
+require 'date'
+
+require_relative 'pdf_parsing/name_extractor'
+require_relative 'pdf_parsing/skills_extractor'
+require_relative 'pdf_parsing/experience_extractor'
+
+class PdfParserService
+  include PdfParsing::NameExtractor
+  include PdfParsing::SkillsExtractor
+  include PdfParsing::ExperienceExtractor
+
+  PERIOD_REGEX = /
+  (
+    (Jan(uary)?|Feb(ruary)?|Mar(ch)?|Apr(il)?|May|Jun(e)?|
+     Jul(y)?|Aug(ust)?|Sep(tember)?|Oct(ober)?|Nov(ember)?|Dec(ember)?)
+    [\s\/\-\.]?
+    \d{4}
+  |
+    \d{1,2}[\/\-]\d{4}
+  |
+    \d{4}
+  )
+  \s*[\-]\s*
+  (
+    (Present|Prezent|Current)
+  |
+    (Jan(uary)?|Feb(ruary)?|Mar(ch)?|Apr(il)?|May|Jun(e)?|
+     Jul(y)?|Aug(ust)?|Sep(tember)?|Oct(ober)?|Nov(ember)?|Dec(ember)?)
+    [\s\/\-\.]?
+    \d{4}
+  |
+    \d{1,2}[\/\-]\d{4}
+  |
+    \d{4}
+  )
+/ix.freeze
+
+  def initialize(file)
+    @file = file
+    @tmp_pdf_path = Rails.root.join("tmp/cv_#{SecureRandom.hex}.pdf")
+    @tmp_xml_path = @tmp_pdf_path.sub_ext('.xml')
+  end
+
+  def extract_text
+    save_file_locally
+    generate_xml_with_poppler
+    doc = Nokogiri::XML(File.read(@tmp_xml_path))
+
+    ordered_text = extract_ordered_text(doc)
+    experiences = extract_raw_experiences(doc)
+
+    {
+      name: extract_name(doc),
+      email: extract_email(ordered_text.join("\n")),
+      experiences: experiences,
+      current_job: extract_current_job(experiences),
+      total_experience_years: calculate_total_experience_years(experiences),
+      skills: extract_skills(doc),
+      text: ordered_text.join("\n")
+    }
+  ensure
+    cleanup_temp_files
+  end
+
+  def extract_ordered_text(doc)
+    texts_by_column = Hash.new { |h, k| h[k] = [] }
+
+    doc.xpath('//text').each do |node|
+      text = node.text.strip
+      next if text.blank?
+
+      col_key = (node['left'].to_i / 50) * 50
+      texts_by_column[col_key] << { top: node['top'].to_i, text: text }
+    end
+
+    texts_by_column.sort_by { |left, _| left }
+                   .flat_map { |_, lines| lines.sort_by { |l| l[:top] }.map { |l| l[:text] } }
+  end
+
+  private
+
+  def extract_email(text)
+    match = text.match(/\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/)
+    match ? match[0] : 'Unknown'
+  end
+
+  def save_file_locally
+    File.binwrite(@tmp_pdf_path, @file.download)
+  end
+
+  def generate_xml_with_poppler
+    system('pdftohtml', '-xml', '-nodrm', @tmp_pdf_path.to_s, @tmp_xml_path.to_s)
+    raise 'Failed to generate XML with pdftohtml' unless File.exist?(@tmp_xml_path)
+  end
+
+  def cleanup_temp_files
+    FileUtils.rm_f(@tmp_pdf_path)
+    FileUtils.rm_f(@tmp_xml_path)
+  end
+
+  def extract_current_job(experiences)
+    experiences.find { |exp| exp[:period].downcase.match?(/present|prezent|current/) }
+  end
+
+  def calculate_total_experience_years(experiences)
+    total_months = experiences.sum do |exp|
+      next 0 unless exp[:period] =~ PERIOD_REGEX
+
+      from_str, to_str = exp[:period].split(/-+/).map(&:strip)
+      from_date = parse_date_string(from_str)
+      to_date = parse_date_string(to_str) || Time.zone.today
+
+      next 0 unless from_date
+
+      months = ((to_date.year * 12) + to_date.month) - ((from_date.year * 12) + from_date.month)
+      [months, 0].max
+    end
+
+    (total_months / 12.0).round(1)
+  end
+
+  def parse_date_string(date_str)
+    return Time.zone.today if date_str.downcase.match?(/present|prezent|current/)
+    return Date.new(date_str.to_i, 1, 1) if date_str.strip =~ /^\d{4}$/
+
+    begin
+      Date.parse(date_str)
+    rescue StandardError
+      nil
+    end
+  end
+end

--- a/app/services/pdf_parsing/experience_extractor.rb
+++ b/app/services/pdf_parsing/experience_extractor.rb
@@ -1,0 +1,45 @@
+module PdfParsing
+  module ExperienceExtractor
+    def extract_raw_experiences(doc)
+      text_nodes = extract_text_nodes(doc)
+
+      text_nodes.each_with_index.with_object([]) do |(node, idx), blocks|
+        next unless period_line?(node[:text])
+
+        experience = build_experience_block(text_nodes, idx)
+        blocks << experience if experience
+      end
+    end
+
+    private
+
+    def extract_text_nodes(doc)
+      doc.xpath('//text').map do |node|
+        {
+          text: node.text.strip,
+          top: node['top'].to_i,
+          left: node['left'].to_i,
+          font: node['font'].to_i
+        }
+      end
+    end
+
+    def period_line?(text)
+      text =~ PdfParserService::PERIOD_REGEX
+    end
+
+    def build_experience_block(nodes, idx)
+      period  = nodes[idx][:text]
+      company = nodes[idx - 1]&.[](:text)
+      title   = nodes[idx - 2]&.[](:text)
+
+      return nil if [company, title].any?(&:blank?)
+
+      {
+        title: title,
+        company: company,
+        period: period
+      }
+    end
+  end
+end

--- a/app/services/pdf_parsing/name_extractor.rb
+++ b/app/services/pdf_parsing/name_extractor.rb
@@ -1,0 +1,46 @@
+module PdfParsing
+  module NameExtractor
+    def extract_name(doc)
+      biggest_font_id = find_biggest_font_id(doc)
+      return 'Unknown' unless biggest_font_id
+
+      name_node = find_likely_name_node(doc, biggest_font_id)
+      format_name_text(name_node)
+    end
+
+    def extract_font_sizes(doc)
+      doc.xpath('//fontspec').each_with_object({}) do |font_node, hash|
+        font_id = font_node['id'].to_i
+        size = font_node['size'].to_f
+        hash[font_id] = size
+      end
+    end
+
+    private
+
+    def find_biggest_font_id(doc)
+      font_sizes = extract_font_sizes(doc)
+      font_sizes.max_by { |_, size| size.to_f }&.first
+    end
+
+    def find_likely_name_node(doc, font_id)
+      skip_words = %w[cv curriculum vitae resume]
+
+      doc.xpath('//text')
+         .select { |n| n['font'].to_i == font_id.to_i }
+         .sort_by { |n| n['top'].to_i }
+         .find do |node|
+        text = node.text.strip.gsub("\u00A0", ' ')
+        word_count = text.split.size
+        word_count.between?(2, 4) && skip_words.none? { |w| text.downcase.include?(w) }
+      end
+    end
+
+    def format_name_text(node)
+      return 'Unknown' unless node
+
+      name = node.text.strip.gsub("\u00A0", ' ')
+      name.empty? ? 'Unknown' : name
+    end
+  end
+end

--- a/app/services/pdf_parsing/skills_extractor.rb
+++ b/app/services/pdf_parsing/skills_extractor.rb
@@ -1,0 +1,54 @@
+module PdfParsing
+  module SkillsExtractor
+    def extract_skills(doc)
+      text_nodes = extract_text_nodes(doc)
+      index = find_skills_index(text_nodes)
+      return [] unless index
+
+      skill_lines = extract_skill_lines(text_nodes, index)
+      format_skills(skill_lines)
+    end
+
+    private
+
+    def extract_text_nodes(doc)
+      doc.xpath('//text').map do |node|
+        {
+          text: node.text.strip,
+          top: node['top'].to_i,
+          left: node['left'].to_i,
+          font: node['font'].to_i
+        }
+      end
+    end
+
+    def find_skills_index(nodes)
+      nodes.index { |n| n[:text].strip.downcase == 'skills' }
+    end
+
+    def extract_skill_lines(nodes, index)
+      first = nodes[index + 1]
+      return [] unless first
+
+      font_id = first[:font]
+      lines = [first[:text]]
+
+      nodes[(index + 2)..].each do |node|
+        break unless node[:font] == font_id
+
+        lines << node[:text]
+      end
+
+      lines
+    end
+
+    def format_skills(lines)
+      lines
+        .join(' ')
+        .split(/[,;\u2022\n]/)
+        .map(&:strip)
+        .reject(&:empty?)
+        .uniq
+    end
+  end
+end

--- a/spec/integration/cv_upload_spec.rb
+++ b/spec/integration/cv_upload_spec.rb
@@ -79,6 +79,38 @@ RSpec.describe 'CV Upload API', type: :request do
           cv.id
         end
 
+        schema type: :object,
+               properties: {
+                 name: { type: :string },
+                 email: { type: :string },
+                 experiences: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     properties: {
+                       title: { type: :string },
+                       company: { type: :string },
+                       period: { type: :string }
+                     }
+                   }
+                 },
+                 current_job: {
+                   type: :object,
+                   nullable: true,
+                   properties: {
+                     title: { type: :string },
+                     company: { type: :string },
+                     period: { type: :string }
+                   }
+                 },
+                 total_experience_years: { type: :number },
+                 skills: {
+                   type: :array,
+                   items: { type: :string }
+                 },
+                 text: { type: :string }
+               }
+
         run_test!
       end
 

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -54,6 +54,44 @@ paths:
       responses:
         '200':
           description: Text extracted successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  email:
+                    type: string
+                  experiences:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        title:
+                          type: string
+                        company:
+                          type: string
+                        period:
+                          type: string
+                  current_job:
+                    type: object
+                    nullable: true
+                    properties:
+                      title:
+                        type: string
+                      company:
+                        type: string
+                      period:
+                        type: string
+                  total_experience_years:
+                    type: number
+                  skills:
+                    type: array
+                    items:
+                      type: string
+                  text:
+                    type: string
         '404':
           description: CV not found
 servers:


### PR DESCRIPTION
Fixes: https://github.com/smaria03/cvparser-backend/issues/3

**Changes**
Added logic to extract name, email, job titles, experience, and skills from CV text.

**Before**
There was no functionality to extract structured data from uploaded CVs.

**After**
<img width="841" height="647" alt="Screenshot 2025-09-09 at 19 49 17" src="https://github.com/user-attachments/assets/17fd867e-19ac-423f-a9bf-11ff476673af" />
