### PR TITLE
Feature / [12] Add save_to_sheet endpoint and refactor extract_summary

### DIFF
--- a/app/controllers/api/cvs_controller.rb
+++ b/app/controllers/api/cvs_controller.rb
@@ -56,12 +56,21 @@ module Api
       return render json: { error: 'CV not found' }, status: :not_found unless cv&.file&.attached?
 
       result = PdfParserService.new(cv.file).extract_relevant_data
+      render json: result
+    end
 
-      if result
-        write_to_google_sheets(result) if write_to_sheet_param?
-        render json: result, status: :ok
-      else
-        render json: { error: 'Failed to extract text' }, status: :unprocessable_entity
+    def save_to_sheet
+      summary = params.require(:summary).permit(
+        :name,
+        :email,
+        :total_experience_years
+      )
+
+      begin
+        write_to_google_sheets(summary.to_h.symbolize_keys)
+        render json: { message: 'Saved to Google Sheets successfully' }, status: :ok
+      rescue StandardError => e
+        render json: { error: e.message }, status: :unprocessable_entity
       end
     end
 
@@ -76,10 +85,6 @@ module Api
       )
     rescue StandardError => e
       Rails.logger.error "[GoogleSheets] Failed to append row: #{e.message}"
-    end
-
-    def write_to_sheet_param?
-      ActiveModel::Type::Boolean.new.cast(params[:write_to_sheet])
     end
   end
 end

--- a/app/services/pdf_parsing/experience_extractor.rb
+++ b/app/services/pdf_parsing/experience_extractor.rb
@@ -85,8 +85,16 @@ module PdfParsing
       job_lines = nodes[[idx - lines_before, 0].max...idx]
                   .pluck(:text)
                   .compact_blank
-                  .join(' ')
-      job_details = [job_lines, inline_job].compact_blank.join(' ')
+                  .join(', ')
+      job_details = [job_lines, inline_job].compact_blank.join(', ')
+
+      job_details = job_details
+                .gsub(/[\/\-\|•]/, '')
+                .gsub(', ,', ',')
+                .gsub('  ', ' ')
+                .strip
+                .sub(/,\z/, '')
+
       [period, job_details]
     end
 

--- a/app/services/pdf_parsing/experience_extractor.rb
+++ b/app/services/pdf_parsing/experience_extractor.rb
@@ -89,11 +89,11 @@ module PdfParsing
       job_details = [job_lines, inline_job].compact_blank.join(', ')
 
       job_details = job_details
-                .gsub(/[\/\-\|•]/, '')
-                .gsub(', ,', ',')
-                .gsub('  ', ' ')
-                .strip
-                .sub(/,\z/, '')
+                    .gsub(/[\/\-\|•]/, '')
+                    .gsub(', ,', ',')
+                    .gsub('  ', ' ')
+                    .strip
+                    .sub(/,\z/, '')
 
       [period, job_details]
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,6 @@ Rails.application.routes.draw do
     get 'cvs/:id/extract_text', to: 'cvs#extract_text'
     get 'cvs/:id/extract_sections', to: 'cvs#extract_sections'
     get 'cvs/:id/extract_summary', to: 'cvs#extract_summary'
+    post 'cvs/save_to_sheet', to: 'cvs#save_to_sheet'
   end
 end

--- a/lib/google_sheets_writer.rb
+++ b/lib/google_sheets_writer.rb
@@ -7,7 +7,7 @@ class GoogleSheetsWriter
   RANGE = 'Foaie1!A:E'.freeze
 
   def initialize
-    keyfile = Rails.root.join('config/credentials/cvparser-471707-86d83e2e17ab.json')
+    keyfile = Rails.root.join('config/credentials/cvparser-471707-ea26336728d2.json')
     authorizer = Google::Auth::ServiceAccountCredentials.make_creds(
       json_key_io: File.open(keyfile),
       scope: SCOPE

--- a/spec/integration/cv_upload_spec.rb
+++ b/spec/integration/cv_upload_spec.rb
@@ -67,8 +67,6 @@ RSpec.describe 'CV Upload API', type: :request do
       tags 'CVs'
       produces 'application/json'
       parameter name: :id, in: :path, type: :string, required: true, description: 'CV ID'
-      parameter name: :write_to_sheet, in: :query, type: :boolean, required: false,
-                description: 'Append to Google Sheets'
 
       response '200', 'Summary extracted successfully' do
         let(:id) do
@@ -206,6 +204,43 @@ RSpec.describe 'CV Upload API', type: :request do
 
       response '404', 'CV not found' do
         let(:id) { 'invalid' }
+        run_test!
+      end
+    end
+  end
+
+  path '/api/cvs/save_to_sheet' do
+    post 'Save extracted CV summary to Google Sheets' do
+      tags 'CVs'
+      consumes 'application/json'
+      produces 'application/json'
+
+      parameter name: :summary, in: :body, required: true, schema: {
+        type: :object,
+        properties: {
+          summary: {
+            type: :object,
+            required: %w[name email total_experience_years],
+            properties: {
+              name: { type: :string, example: 'Maria Silaghi' },
+              email: { type: :string, example: 'smaria.oana@yahoo.com' },
+              total_experience_years: { type: :string, example: '2.5y' }
+            }
+          }
+        }
+      }
+
+      response '200', 'Saved to Google Sheets successfully' do
+        let(:summary) do
+          {
+            summary: {
+              name: 'Maria Silaghi',
+              email: 'smaria.oana@yahoo.com',
+              total_experience_years: '2.5y'
+            }
+          }
+        end
+
         run_test!
       end
     end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -51,12 +51,6 @@ paths:
         description: CV ID
         schema:
           type: string
-      - name: write_to_sheet
-        in: query
-        required: false
-        description: Append to Google Sheets
-        schema:
-          type: boolean
       responses:
         '200':
           description: Summary extracted successfully
@@ -169,6 +163,38 @@ paths:
                                 type: integer
         '404':
           description: CV not found
+  "/api/cvs/save_to_sheet":
+    post:
+      summary: Save extracted CV summary to Google Sheets
+      tags:
+      - CVs
+      parameters: []
+      responses:
+        '200':
+          description: Saved to Google Sheets successfully
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                summary:
+                  type: object
+                  required:
+                  - name
+                  - email
+                  - total_experience_years
+                  properties:
+                    name:
+                      type: string
+                      example: Maria Silaghi
+                    email:
+                      type: string
+                      example: smaria.oana@yahoo.com
+                    total_experience_years:
+                      type: string
+                      example: 2.5y
+        required: true
 servers:
 - url: http://{defaultHost}
   variables:


### PR DESCRIPTION
Fixes: https://github.com/smaria03/cvparser-backend/issues/12

Frontend PR: https://github.com/smaria03/cvparser-frontend/pull/2

**Changes**
Refactor extract_summary to only return data, and add new endpoint save_to_sheet for writing to Google Sheets

**Before**
The extract_summary endpoint was extracting data and writing it directly to the spreadsheet without allowing any edits from the frontend.

**After**
The extract_summary endpoint only returns parsed data. A new endpoint allows the frontend to submit edited data and save it to the spreadsheet.