### PR TITLE
Feature / [15]  Allow users to choose applied job (backend)

### DIFF
--- a/app/controllers/api/cvs_controller.rb
+++ b/app/controllers/api/cvs_controller.rb
@@ -59,12 +59,24 @@ module Api
       render json: result
     end
 
+    VALID_JOBS = [
+      'Full Stack Software Engineer',
+      'Internship',
+      'QA'
+    ].freeze
+
     def save_to_sheet
       summary = params.require(:summary).permit(
         :name,
         :email,
-        :total_experience_years
+        :total_experience_years,
+        :applied_for
       )
+
+      applied_for = summary[:applied_for]
+      unless VALID_JOBS.include?(applied_for)
+        return render json: { error: 'Invalid job' }, status: :unprocessable_entity
+      end
 
       begin
         write_to_google_sheets(summary.to_h.symbolize_keys)
@@ -80,7 +92,7 @@ module Api
       GoogleSheetsWriter.new.append_row(
         name: data[:name],
         email: data[:email],
-        applied_for: 'Full Stack Software Engineer',
+        applied_for: data[:applied_for],
         experience: data[:total_experience_years]
       )
     rescue StandardError => e

--- a/spec/integration/cv_upload_spec.rb
+++ b/spec/integration/cv_upload_spec.rb
@@ -224,7 +224,12 @@ RSpec.describe 'CV Upload API', type: :request do
             properties: {
               name: { type: :string, example: 'Maria Silaghi' },
               email: { type: :string, example: 'smaria.oana@yahoo.com' },
-              total_experience_years: { type: :string, example: '2.5y' }
+              total_experience_years: { type: :string, example: '2.5y' },
+              applied_for: {
+                type: :string,
+                example: 'Internship',
+                enum: ['Full Stack Software Engineer', 'Internship', 'QA']
+              }
             }
           }
         }
@@ -236,7 +241,8 @@ RSpec.describe 'CV Upload API', type: :request do
             summary: {
               name: 'Maria Silaghi',
               email: 'smaria.oana@yahoo.com',
-              total_experience_years: '2.5y'
+              total_experience_years: '2.5y',
+              applied_for: 'Internship'
             }
           }
         end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -194,6 +194,13 @@ paths:
                     total_experience_years:
                       type: string
                       example: 2.5y
+                    applied_for:
+                      type: string
+                      example: Internship
+                      enum:
+                      - Full Stack Software Engineer
+                      - Internship
+                      - QA
         required: true
 servers:
 - url: http://{defaultHost}


### PR DESCRIPTION
Fixes: https://github.com/smaria03/cvparser-backend/issues/15

Frontend PR: 

**Changes**
Added backend support for the `applied_for` field.

**Before**
The applied job was hardcoded as "Full Stack Software Engineer" when saving CV data to Google Sheets.

**After**
The backend now accepts an `applied_for` value.