### PR TITLE
Feature / [17] Allow selecting sheet when saving CV summary (backend)

### DIFF
--- a/app/controllers/api/cvs_controller.rb
+++ b/app/controllers/api/cvs_controller.rb
@@ -70,20 +70,35 @@ module Api
         :name,
         :email,
         :total_experience_years,
-        :applied_for
+        :applied_for,
+        :sheet
       )
 
       applied_for = summary[:applied_for]
+      sheet = summary[:sheet]
       unless VALID_JOBS.include?(applied_for)
         return render json: { error: 'Invalid job' }, status: :unprocessable_entity
       end
 
+      available_sheets = GoogleSheetsWriter.new.list_sheets
+      unless available_sheets.include?(sheet)
+        return render json: { error: "Sheet #{sheet} does not exist." }, status: :unprocessable_entity
+      end
+
       begin
-        write_to_google_sheets(summary.to_h.symbolize_keys)
+        write_to_google_sheets(summary.to_h.symbolize_keys.merge(sheet: sheet))
         render json: { message: 'Saved to Google Sheets successfully' }, status: :ok
       rescue StandardError => e
         render json: { error: e.message }, status: :unprocessable_entity
       end
+    end
+
+    def list_sheets
+      sheets = GoogleSheetsWriter.new.list_sheets
+      render json: { sheets: sheets }, status: :ok
+    rescue StandardError => e
+      Rails.logger.error "[GoogleSheets] Failed to list sheets: #{e.message}"
+      render json: { error: e.message }, status: :unprocessable_entity
     end
 
     private
@@ -93,10 +108,12 @@ module Api
         name: data[:name],
         email: data[:email],
         applied_for: data[:applied_for],
-        experience: data[:total_experience_years]
+        experience: data[:total_experience_years],
+        sheet: data[:sheet]
       )
     rescue StandardError => e
       Rails.logger.error "[GoogleSheets] Failed to append row: #{e.message}"
+      raise e
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,6 @@ Rails.application.routes.draw do
     get 'cvs/:id/extract_sections', to: 'cvs#extract_sections'
     get 'cvs/:id/extract_summary', to: 'cvs#extract_summary'
     post 'cvs/save_to_sheet', to: 'cvs#save_to_sheet'
+    get 'cvs/sheets', to: 'cvs#list_sheets'
   end
 end

--- a/lib/google_sheets_writer.rb
+++ b/lib/google_sheets_writer.rb
@@ -4,7 +4,6 @@ require 'googleauth'
 class GoogleSheetsWriter
   SCOPE = Google::Apis::SheetsV4::AUTH_SPREADSHEETS
   SPREADSHEET_ID = '1UihqJI_GpNIKvwg8gDz7pJ3r8loZt32o_1x2sgLVCTU'.freeze
-  RANGE = 'Foaie1!A:E'.freeze
 
   def initialize
     keyfile = Rails.root.join('config/credentials/cvparser-471707-ea26336728d2.json')
@@ -17,15 +16,21 @@ class GoogleSheetsWriter
     @service.authorization = authorizer
   end
 
-  def append_row(name:, email:, applied_for:, experience:)
+  def append_row(name:, email:, applied_for:, experience:, sheet: 'Full Stack Software Engineer')
+    range = "#{sheet}!A:E"
     values = [[name, email, applied_for, '', experience.to_s]]
     value_range = Google::Apis::SheetsV4::ValueRange.new(values: values)
 
     @service.append_spreadsheet_value(
       SPREADSHEET_ID,
-      RANGE,
+      range,
       value_range,
       value_input_option: 'RAW'
     )
+  end
+
+  def list_sheets
+    spreadsheet = @service.get_spreadsheet(SPREADSHEET_ID)
+    spreadsheet.sheets.map { |s| s.properties.title }
   end
 end

--- a/spec/integration/cv_upload_spec.rb
+++ b/spec/integration/cv_upload_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe 'CV Upload API', type: :request do
         properties: {
           summary: {
             type: :object,
-            required: %w[name email total_experience_years],
+            required: %w[name email total_experience_years applied_for sheet],
             properties: {
               name: { type: :string, example: 'Maria Silaghi' },
               email: { type: :string, example: 'smaria.oana@yahoo.com' },
@@ -229,6 +229,11 @@ RSpec.describe 'CV Upload API', type: :request do
                 type: :string,
                 example: 'Internship',
                 enum: ['Full Stack Software Engineer', 'Internship', 'QA']
+              },
+              sheet: {
+                type: :string,
+                example: 'Internship',
+                description: 'The name of the sheet where the row should be saved'
               }
             }
           }
@@ -236,16 +241,75 @@ RSpec.describe 'CV Upload API', type: :request do
       }
 
       response '200', 'Saved to Google Sheets successfully' do
+        schema type: :object,
+               properties: {
+                 message: { type: :string }
+               },
+               required: ['message']
+
+        example 'application/json', :success_example, {
+          message: 'Saved to Google Sheets successfully'
+        }
         let(:summary) do
           {
             summary: {
               name: 'Maria Silaghi',
               email: 'smaria.oana@yahoo.com',
               total_experience_years: '2.5y',
-              applied_for: 'Internship'
+              applied_for: 'Internship',
+              sheet: 'Internship'
             }
           }
         end
+
+        run_test!
+      end
+
+      response '422', 'Validation failed' do
+        schema type: :object,
+               properties: {
+                 error: { type: :string }
+               },
+               required: ['error']
+
+        example 'application/json', :invalid_job_example, {
+          error: 'Invalid job title'
+        }
+
+        example 'application/json', :invalid_sheet_example, {
+          error: 'Sheet does not exist.'
+        }
+
+        let(:summary) do
+          {
+            summary: {
+              name: 'Maria Silaghi',
+              email: 'smaria.oana@yahoo.com',
+              total_experience_years: '2.5y',
+              applied_for: 'InvalidRole',
+              sheet: 'DoesNotExist'
+            }
+          }
+        end
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/cvs/sheets' do
+    get 'List available sheets' do
+      tags 'CVs'
+      produces 'application/json'
+
+      response '200', 'Sheets listed successfully' do
+        schema type: :object,
+               properties: {
+                 sheets: {
+                   type: :array,
+                   items: { type: :string }
+                 }
+               }
 
         run_test!
       end

--- a/spec/integration/cv_upload_spec.rb
+++ b/spec/integration/cv_upload_spec.rb
@@ -242,9 +242,11 @@ RSpec.describe 'CV Upload API', type: :request do
 
       response '200', 'Saved to Google Sheets successfully' do
         before do
-          allow_any_instance_of(GoogleSheetsWriter)
-            .to receive(:append_row)
-                  .and_return(true)
+          allow(GoogleSheetsWriter)
+            .to receive(:new)
+            .and_return(double(list_sheets:
+                                       ['Internship', 'QA', 'Full Stack Software Engineer'],
+                               append_row: true))
         end
         schema type: :object,
                properties: {
@@ -272,9 +274,11 @@ RSpec.describe 'CV Upload API', type: :request do
 
       response '422', 'Validation failed' do
         before do
-          allow_any_instance_of(GoogleSheetsWriter)
-            .to receive(:append_row)
-                  .and_raise(ArgumentError, 'Sheet does not exist.')
+          fake_writer = double('GoogleSheetsWriter',
+                               list_sheets: ['Internship', 'QA', 'Full Stack Software Engineer'])
+          allow(fake_writer).to receive(:append_row).and_raise(ArgumentError,
+                                                               'Sheet does not exist.')
+          allow(GoogleSheetsWriter).to receive(:new).and_return(fake_writer)
         end
         schema type: :object,
                properties: {
@@ -314,9 +318,10 @@ RSpec.describe 'CV Upload API', type: :request do
 
       response '200', 'Sheets listed successfully' do
         before do
-          allow_any_instance_of(GoogleSheetsWriter)
-            .to receive(:list_sheets)
-                  .and_return(['Internship', 'QA', 'Full Stack Software Engineer'])
+          allow(GoogleSheetsWriter)
+            .to receive(:new)
+            .and_return(double(list_sheets:
+                                       ['Internship', 'QA', 'Full Stack Software Engineer']))
         end
         schema type: :object,
                properties: {

--- a/spec/integration/cv_upload_spec.rb
+++ b/spec/integration/cv_upload_spec.rb
@@ -241,6 +241,11 @@ RSpec.describe 'CV Upload API', type: :request do
       }
 
       response '200', 'Saved to Google Sheets successfully' do
+        before do
+          allow_any_instance_of(GoogleSheetsWriter)
+            .to receive(:append_row)
+                  .and_return(true)
+        end
         schema type: :object,
                properties: {
                  message: { type: :string }
@@ -266,6 +271,11 @@ RSpec.describe 'CV Upload API', type: :request do
       end
 
       response '422', 'Validation failed' do
+        before do
+          allow_any_instance_of(GoogleSheetsWriter)
+            .to receive(:append_row)
+                  .and_raise(ArgumentError, 'Sheet does not exist.')
+        end
         schema type: :object,
                properties: {
                  error: { type: :string }
@@ -303,6 +313,11 @@ RSpec.describe 'CV Upload API', type: :request do
       produces 'application/json'
 
       response '200', 'Sheets listed successfully' do
+        before do
+          allow_any_instance_of(GoogleSheetsWriter)
+            .to receive(:list_sheets)
+                  .and_return(['Internship', 'QA', 'Full Stack Software Engineer'])
+        end
         schema type: :object,
                properties: {
                  sheets: {

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -172,6 +172,37 @@ paths:
       responses:
         '200':
           description: Saved to Google Sheets successfully
+          content:
+            application/json:
+              examples:
+                success_example:
+                  value:
+                    message: Saved to Google Sheets successfully
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                - message
+        '422':
+          description: Validation failed
+          content:
+            application/json:
+              examples:
+                invalid_job_example:
+                  value:
+                    error: Invalid job title
+                invalid_sheet_example:
+                  value:
+                    error: Sheet does not exist.
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                required:
+                - error
       requestBody:
         content:
           application/json:
@@ -184,6 +215,8 @@ paths:
                   - name
                   - email
                   - total_experience_years
+                  - applied_for
+                  - sheet
                   properties:
                     name:
                       type: string
@@ -201,7 +234,28 @@ paths:
                       - Full Stack Software Engineer
                       - Internship
                       - QA
+                    sheet:
+                      type: string
+                      example: Internship
+                      description: The name of the sheet where the row should be saved
         required: true
+  "/api/cvs/sheets":
+    get:
+      summary: List available sheets
+      tags:
+      - CVs
+      responses:
+        '200':
+          description: Sheets listed successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sheets:
+                    type: array
+                    items:
+                      type: string
 servers:
 - url: http://{defaultHost}
   variables:


### PR DESCRIPTION
Fixes: https://github.com/smaria03/cvparser-backend/issues/17

Frontend PR: 

**Changes**
Added support for choosing the sheet when saving parsed CV data.

**Before**
All CVs were written to a default sheet. 

**After**
<img width="854" height="464" alt="Screenshot 2025-09-18 at 12 47 49" src="https://github.com/user-attachments/assets/1cc67e5b-b4d3-4318-94a1-278b5facc11f" />

<img width="853" height="429" alt="Screenshot 2025-09-18 at 12 48 19" src="https://github.com/user-attachments/assets/9078d61a-50f3-4bf7-93a8-9120e8bede32" />

